### PR TITLE
Apply new boxes and fix some typos in blockchain primer

### DIFF
--- a/slides/public-blockchain-primer.tex
+++ b/slides/public-blockchain-primer.tex
@@ -321,9 +321,9 @@ All transaction types modify the data structure. There must be a consensus regar
 \end{figure}
 
 \begin{itemize}
-	\item<2-> \textbf{Proof-of-Authority (PoA):} one centralized party decides
-	\item<3-> \textbf{Proof-of-Work (PoW):} decentralized lottery
-	\item<4-> \textbf{Proof of Stake (PoS):} validation in proportion to collateral  
+	\item<2-> \textbf{Proof-of-Authority (PoA):} a centralized party decides
+	\item<3-> \textbf{Proof-of-Work (PoW):} validation in proportion to computational resources
+	\item<4-> \textbf{Proof-of-Stake (PoS):} validation in proportion to collateral  
 \end{itemize}
 
 \uncover <5->{


### PR DESCRIPTION
# Description

I have applied @kmschuler's box update to the public blockchain primer slide deck. Moreover, I have fixed some typos.

## Type of Change

- [X] Typo fix (Changes that fix spelling errors)
- [X] Minor feature (Small changes to slides or other files)
- [ ] Major feature (New files or assets, large changes to files)

# Checklist:

- [X] I have performed a self-review of my own changes
- [X] I have made sure that any changed LaTeX files compile properly
- [X] I have assigned at least one reviewer
