### PR TITLE
Remove stack highlighting from DeFi stack template

### DIFF
--- a/assets/figures/defi_stack.tex
+++ b/assets/figures/defi_stack.tex
@@ -12,7 +12,7 @@
 	\filldraw[color = brightanthracite!50, thick, draw=black] (0,5.25) rectangle ++(15,1.5);
 	\node [right, xshift = 0.2cm, text = anthracite] at (0,6) {\textbf{Application Layer}};
 
-	\filldraw[color = mint!50, ultra thick, draw=strongmint] (0,7) rectangle ++(15,1.5);
+	\filldraw[color = brightanthracite!50, thick, draw=black] (0,7) rectangle ++(15,1.5);
 	\node [right, xshift = 0.2cm, text = anthracite] at (0,7.75) {\textbf{Aggregation Layer}};
 
 % Settlement components
@@ -100,9 +100,9 @@
 % Aggregation components
 	
 	% Boxes
-	\draw [fill = white, thick, draw=strongmint ] (4, 7.2) rectangle  ++(3.42,1.1) node [midway, text width = 3.2cm, align = center ] {Aggregator 1};
-	\draw [fill = white, thick, draw=strongmint ] (7.67, 7.2) rectangle  ++(3.42,1.1) node [midway, text width = 3.2cm, align = center ] {Aggregator 2};
-	\draw [fill = white, thick, draw=strongmint ] (11.34, 7.2) rectangle  ++(3.41,1.1) node [midway, text width = 3.2cm, align = center ] {Aggregator 3};
+	\draw [fill = white, thick, draw=anthracite ] (4, 7.2) rectangle  ++(3.42,1.1) node [midway, text width = 3.2cm, align = center ] {Aggregator 1};
+	\draw [fill = white, thick, draw=anthracite ] (7.67, 7.2) rectangle  ++(3.42,1.1) node [midway, text width = 3.2cm, align = center ] {Aggregator 2};
+	\draw [fill = white, thick, draw=anthracite ] (11.34, 7.2) rectangle  ++(3.41,1.1) node [midway, text width = 3.2cm, align = center ] {Aggregator 3};
 	
 	%Lines
 	


### PR DESCRIPTION
# Description
The DeFi stack is referenced by multiple slide decks. There must be a neutral version without highlighting. If the neutral version is changed, these changes may have unexpected consequences for other slide decks. I suspect this is what happened for the intro slide deck. If you want to highlight a specific layer, please create a new version of the stack or use overlays.

## Type of Change
- [X] Minor feature (Small changes to slides or other files)

# Checklist:

- [X] I have performed a self-review of my own changes
- [X] I have made sure that any changed LaTeX files compile properly
- [X] I have assigned at least one reviewer
